### PR TITLE
✖️ Handle meetings with null StartTime

### DIFF
--- a/src/ts/Data/Models.ts
+++ b/src/ts/Data/Models.ts
@@ -69,7 +69,7 @@ export interface MeetingDetails
     StartDate: string;
     EndDate: string;
     DaysOfWeek: string;
-    StartTime: string;
+    StartTime: string | null;
     Duration: string;
     RoomId: string;
     Instructors: Instructor[];

--- a/src/ts/Pages/ClassPage.ts
+++ b/src/ts/Pages/ClassPage.ts
@@ -150,14 +150,17 @@ export class ClassPage extends Page
             daysCol.innerText = Utilities.getDaysOfWeek(meeting.DaysOfWeek).join("\u00a0");
             meetingRow.appendChild(daysCol);
 
-            let timeCol = document.createElement("td");
-            let startTime = Utilities.getTimeString(
-                new Date(meeting.StartDate + "T" + meeting.StartTime));
-            let endTime = Utilities.getTimeString(
-                Utilities.datePlusDuration(
-                    new Date(meeting.StartDate + "T" + meeting.StartTime), meeting.Duration));
-            timeCol.innerText = `${startTime} - ${endTime}`
-            meetingRow.appendChild(timeCol);
+            if (meeting.StartTime !== null)
+            {
+                let timeCol = document.createElement("td");
+                let startTime = Utilities.getTimeString(
+                    new Date(meeting.StartDate + "T" + meeting.StartTime));
+                let endTime = Utilities.getTimeString(
+                    Utilities.datePlusDuration(
+                        new Date(meeting.StartDate + "T" + meeting.StartTime), meeting.Duration));
+                timeCol.innerText = `${startTime} - ${endTime}`
+                meetingRow.appendChild(timeCol);
+            }
         }
 
         return meetingTableElement;

--- a/src/ts/Pages/CoursePage.ts
+++ b/src/ts/Pages/CoursePage.ts
@@ -130,10 +130,13 @@ export class CoursePage extends Page
                     let daysCol = document.createElement("td");
                     daysCol.innerText = Utilities.getDaysOfWeek(meeting.DaysOfWeek).join("\u00a0");
                     sectionRow.appendChild(daysCol);
-                    let timeCol = document.createElement("td");
-                    timeCol.innerText = Utilities.getTimeString(
-                        new Date(meeting.StartDate + "T" + meeting.StartTime));
-                    sectionRow.appendChild(timeCol);
+                    if (meeting.StartTime !== null)
+                    {
+                        let timeCol = document.createElement("td");
+                        timeCol.innerText = Utilities.getTimeString(
+                            new Date(meeting.StartDate + "T" + meeting.StartTime));
+                        sectionRow.appendChild(timeCol);
+                    }
                     tableBodyElement.appendChild(sectionRow);
                 }
 


### PR DESCRIPTION
Recent Purdue.io schema changes allow StartTime to be `null`, which would cause "Invalid Date" to show on Class and Section pages.

This change omits the start/end time instead.